### PR TITLE
Correct the source of the NPM badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _A middleware to trigger analytics for white-listed actions_
 
-[![npm](https://img.shields.io/npm/dt/reverse-number.svg)](https://www.npmjs.com/package/reverse-number)
+[![npm](https://img.shields.io/npm/dt/reverse-number.svg)](https://www.npmjs.com/package/redux-action-analytics-middleware)
 
 ## Description
 


### PR DESCRIPTION
The badge used to pull the downloads number from the `reverse-number`
package when it should be pulled from the
`redux-action-analytics-middleware` package.