### PR TITLE
Fix the Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - run: yarn
       - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -64,5 +64,5 @@
     "prepack:flow": "flow-copy-source src lib",
     "test": "jest"
   },
-  "version": "2.3.0"
+  "version": "2.4.0"
 }


### PR DESCRIPTION
The Publish workflow was failing due to the fact that the `yarn` command
was not run, therefore no steps in `yarn publish` could be run.

This commit adds the `yarn` step which will fix the workflow.