### PR TITLE
Update `.prettierrc` WRT new defaults

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   arrowParens: "always",
   "semi": false,
-  "singleQuote": true
+  "singleQuote": true,
+  trailingComma: "none"
 }


### PR DESCRIPTION
The default value for `trailingComma` was changed from `none` to `es5`
in version `2.0.0`. This commit now sets the `trailingComma` value in
the `.prettierrc` file to `none` explicitly.